### PR TITLE
Copy of PR #22494: refactor: pass only required fields to useBookingForm and useBookings hooks

### DIFF
--- a/packages/platform/atoms/booker/BookerWebWrapper.tsx
+++ b/packages/platform/atoms/booker/BookerWebWrapper.tsx
@@ -103,7 +103,7 @@ export const BookerWebWrapper = (props: BookerWebWrapperAtomProps) => {
   }, [searchParams, firstNameQueryParam, lastNameQueryParam]);
 
   const bookerForm = useBookingForm({
-    event: event.data,
+    event: event.data ? { bookingFields: event.data.bookingFields } : null,
     sessionEmail: session?.user.email,
     sessionUsername: session?.user.username,
     sessionName: session?.user.name,
@@ -156,7 +156,24 @@ export const BookerWebWrapper = (props: BookerWebWrapperAtomProps) => {
     useApiV2: props.useApiV2,
   });
   const bookings = useBookings({
-    event,
+    event: {
+      data: event.data
+        ? {
+            id: event.data.id,
+            slug: event.data.slug,
+            subsetOfHosts: event.data.subsetOfHosts,
+            requiresConfirmation: event.data.requiresConfirmation,
+            isDynamic: event.data.isDynamic,
+            metadata: event.data.metadata,
+            forwardParamsSuccessRedirect: event.data.forwardParamsSuccessRedirect,
+            successRedirectUrl: event.data.successRedirectUrl,
+            length: event.data.length,
+            recurringEvent: event.data.recurringEvent,
+            schedulingType: event.data.schedulingType,
+            subsetOfUsers: event.data.subsetOfUsers,
+          }
+        : null,
+    },
     hashedLink: props.hashedLink,
     bookingForm: bookerForm.bookingForm,
     metadata: metadata ?? {},


### PR DESCRIPTION
This is a copy of calcom/cal.com#22494

Originally by: hbjORbj


# refactor: pass only required fields to useBookingForm and useBookings hooks

## Summary

Refactored the `BookerWebWrapper` component to pass only the required fields to the `useBookingForm` and `useBookings` hooks instead of passing the entire `event` object. This optimization reduces memory usage and makes the data flow more explicit.

**Changes made:**
- **useBookingForm**: Now receives only `{ bookingFields: event.data.bookingFields }` instead of the full `event.data`
- **useBookings**: Now receives a filtered event object containing only the fields specified in the `IUseBookings` interface: `id`, `slug`, `subsetOfHosts`, `requiresConfirmation`, `isDynamic`, `metadata`, `forwardParamsSuccessRedirect`, `successRedirectUrl`, `length`, `recurringEvent`, `schedulingType`, and `subsetOfUsers`

The refactoring maintains the same event structure (with `data` property) to avoid breaking the hook implementations while significantly reducing the amount of data passed between components.

## Review & Testing Checklist for Human

**⚠️ YELLOW RISK** - Moderate risk due to core functionality impact without end-to-end testing

- [ ] **Test the complete booking flow end-to-end** - Create a test booking to ensure no runtime errors occur and all functionality works correctly
- [ ] **Verify hook interfaces match reality** - Check that the `useBookingForm` and `useBookings` hooks don't internally access any event properties beyond what's defined in their interfaces
- [ ] **Check for hidden data dependencies** - Ensure the extracted fields don't have nested references to other parts of the event object that could cause runtime issues

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    BWW["BookerWebWrapper.tsx<br/>(EDITED)"]:::major-edit
    UBF["useBookingForm.ts<br/>(hook interface)"]:::context
    UB["useBookings.ts<br/>(hook interface)"]:::context
    IUseBookingForm["IUseBookingForm<br/>(interface)"]:::context
    IUseBookings["IUseBookings<br/>(interface)"]:::context
    
    BWW -->|"filtered: { bookingFields }"| UBF
    BWW -->|"filtered: { id, slug, etc. }"| UB
    IUseBookingForm -->|"defines required fields"| UBF
    IUseBookings -->|"defines required fields"| UB
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#ADD8E6
    classDef context fill:#FFFFFF
```

### Notes

- **Type checking passed**: All TypeScript checks pass, confirming the filtered data structure matches the hook interfaces
- **Performance improvement**: Reduces memory usage by only passing required fields instead of the entire event object
- **Maintainability**: Makes data dependencies explicit and easier to track
- **Session info**: Requested by benny@cal.com (@hbjORbj) - Session: https://app.devin.ai/sessions/7197f6bb9f0043a8a65d33e61d386c7d

**⚠️ Important**: While the interfaces suggest this refactoring is safe, the booking flow should be tested manually to ensure no hidden dependencies exist between the hooks and the full event object.